### PR TITLE
remove all references to builtin libraries datetime and csv

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,8 +28,6 @@ To get started, install schengulator using pip.
 pip install schengulator
 ```
 
-Schengulator's only dependencies are **datetime** and **csv** for handling date objects and loading from csv files, respectively. These are usually in-built packages to Python distributions, and therefore there should not be any compatibility issues.
-
 Check that the package works by opening a python console and importing it.
 
 ```python

--- a/docs/_build/html/_sources/quickstart.rst.txt
+++ b/docs/_build/html/_sources/quickstart.rst.txt
@@ -7,8 +7,6 @@ To get started, install schengulator using pip.
    
    pip install schengulator
 
-Schengulator's only dependencies are **datetime** and **csv** for handling date objects and loading from csv files, respectively. These are usually in-built packages to Python distributions, and therefore there should not be any compatibility issues.
-
 Check that the package works by opening a python console and importing it.
    
 .. code-block:: python

--- a/docs/_build/html/quickstart.html
+++ b/docs/_build/html/quickstart.html
@@ -49,7 +49,6 @@
 <div class="highlight-python notranslate"><div class="highlight"><pre><span></span><span class="n">pip</span> <span class="n">install</span> <span class="n">schengulator</span>
 </pre></div>
 </div>
-<p>Schengulator’s only dependencies are <strong>datetime</strong> and <strong>csv</strong> for handling date objects and loading from csv files, respectively. These are usually in-built packages to Python distributions, and therefore there should not be any compatibility issues.</p>
 <p>Check that the package works by opening a python console and importing it.</p>
 <div class="highlight-python notranslate"><div class="highlight"><pre><span></span><span class="n">python3</span>
 <span class="kn">import</span> <span class="nn">schengulator</span>

--- a/schengulator.egg-info/PKG-INFO
+++ b/schengulator.egg-info/PKG-INFO
@@ -47,8 +47,6 @@ To get started, install schengulator using pip.
 pip install schengulator
 ```
 
-Schengulator's only dependencies are **datetime** and **csv** for handling date objects and loading from csv files, respectively. These are usually in-built packages to Python distributions, and therefore there should not be any compatibility issues.
-
 Check that the package works by opening a python console and importing it.
 
 ```python

--- a/schengulator.egg-info/requires.txt
+++ b/schengulator.egg-info/requires.txt
@@ -1,2 +1,0 @@
-datetime
-csv

--- a/setup.py
+++ b/setup.py
@@ -21,7 +21,6 @@ setuptools.setup(
         "Natural Language :: English",
         "Operating System :: OS Independent",
     ],
-    install_requires=['datetime', 'csv'],
     python_requires='>=3',
 )
 


### PR DESCRIPTION
datetime and csv are builtins and have been for a long time. It crashes `pip install` having them in `setup.py`

```
pip install schengulator

ERROR: Could not find a version that satisfies the requirement csv (from schengulator) (from versions: none)
ERROR: No matching distribution found for csv
```
Someone else also tried to do this once :
https://stackoverflow.com/questions/58531236/setup-py-install-requires-built-in-package-include-or-omit

If you look in pypi 
https://pypi.org/
..there are other libraries like datetime2 and datetime3, csv23 and csv342 and there is some slight risk that if this pip install actually executes, it will install one of those obscure libraries and shadow the builtin.

Am otherwise enjoying this library it really does take a program to track this properly, too much to try and do it manually or with excel.